### PR TITLE
Fix Sandbox GetEntryAssembly Issue

### DIFF
--- a/Source/DotSpatial.Projections/GridShift.cs
+++ b/Source/DotSpatial.Projections/GridShift.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using DotSpatial.Projections.Nad;
 using DotSpatial.Projections.Transforms;
 
@@ -69,7 +70,7 @@ namespace DotSpatial.Projections
 
                     bool found = false;
                     // For GSB tables, we need to check for the appropriate sub-table
-                    if (table.SubGrids != null && table.SubGrids.Count > 1)
+                    if (table.SubGrids != null && table.SubGrids.Any())
                     {
                         foreach (NadTable subGrid in table.SubGrids)
                         {

--- a/Source/DotSpatial.Projections/GsbNadTable.cs
+++ b/Source/DotSpatial.Projections/GsbNadTable.cs
@@ -149,8 +149,8 @@ namespace DotSpatial.Projections
                         for (int col = numLambdas - 1; col >= 0; col--)
                         {
                             // shift values are given in "arc-seconds" and need to be converted to radians.
-                            cvs[row][col].Phi = ReadDouble(br) * (Math.PI / 180) / 3600;
-                            cvs[row][col].Lambda = ReadDouble(br) * (Math.PI / 180) / 3600;
+                            cvs[row][col].Phi = ReadFloat(br) * (Math.PI / 180) / 3600;
+                            cvs[row][col].Lambda = ReadFloat(br) * (Math.PI / 180) / 3600;
                         }
                     }
                     Cvs = cvs;
@@ -173,6 +173,27 @@ namespace DotSpatial.Projections
             if (!BitConverter.IsLittleEndian) Array.Reverse(bValue);
             double temp = BitConverter.ToDouble(bValue, 0);
             return temp;
+        }
+
+        /// <summary>
+        /// Gets the double value from the specified position in the byte array
+        /// Using BigEndian format. (TODO: This assumption is not true, at least for Beta2007.gsb, which
+        /// is in LittleEndian). Reversing the bytes produces garbage. I'll tackle this in the next commit.
+        /// </summary>
+        /// <param name="array"></param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        private static float ReadFloat(BinaryReader br)
+        {
+            byte[] temp = new byte[4];
+            br.Read(temp, 0, 4);
+
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(temp);
+            }
+            float value = BitConverter.ToSingle(temp, 0);
+            return value;
         }
 
         #endregion

--- a/Source/DotSpatial.Projections/GsbNadTable.cs
+++ b/Source/DotSpatial.Projections/GsbNadTable.cs
@@ -156,6 +156,8 @@ namespace DotSpatial.Projections
                             // shift values are given in "arc-seconds" and need to be converted to radians.
                             cvs[row][col].Phi = ReadFloat(br) * (Math.PI / 180) / 3600;
                             cvs[row][col].Lambda = ReadFloat(br) * (Math.PI / 180) / 3600;
+
+                            str.Seek(8, SeekOrigin.Current);
                         }
                     }
                     Cvs = cvs;

--- a/Source/DotSpatial.Projections/GsbNadTable.cs
+++ b/Source/DotSpatial.Projections/GsbNadTable.cs
@@ -27,6 +27,11 @@ namespace DotSpatial.Projections
 
         #endregion
 
+        #region Static Variables
+
+        public static bool InputIsBigEndian = true;
+        #endregion
+
         #region Constructors
 
         /// <summary>
@@ -170,7 +175,8 @@ namespace DotSpatial.Projections
         {
             byte[] bValue = new byte[8];
             Array.Copy(array, offset, bValue, 0, 8);
-            if (!BitConverter.IsLittleEndian) Array.Reverse(bValue);
+            if (InputIsBigEndian && BitConverter.IsLittleEndian)
+                Array.Reverse(bValue);
             double temp = BitConverter.ToDouble(bValue, 0);
             return temp;
         }
@@ -188,7 +194,7 @@ namespace DotSpatial.Projections
             byte[] temp = new byte[4];
             br.Read(temp, 0, 4);
 
-            if (BitConverter.IsLittleEndian)
+            if (InputIsBigEndian && BitConverter.IsLittleEndian)
             {
                 Array.Reverse(temp);
             }

--- a/Source/DotSpatial.Projections/GsbNadTable.cs
+++ b/Source/DotSpatial.Projections/GsbNadTable.cs
@@ -29,7 +29,7 @@ namespace DotSpatial.Projections
 
         #region Static Variables
 
-        public static bool InputIsBigEndian = true;
+        public static bool InputIsBigEndian = false;
         #endregion
 
         #region Constructors
@@ -122,12 +122,12 @@ namespace DotSpatial.Projections
             NumLambdas = (int)(Math.Abs(urLam - ll.Lambda) / cs.Lambda + .5) + 1;
             NumPhis = (int)(Math.Abs(urPhi - ll.Phi) / cs.Phi + .5) + 1;
 
-            ll.Lambda *= DEG_TO_RAD;
-            ll.Phi *= DEG_TO_RAD;
+            ll.Lambda = ll.Lambda / 3600 * DEG_TO_RAD;
+            ll.Phi = ll.Phi / 3600 * DEG_TO_RAD;
             LowerLeft = ll;
 
-            cs.Lambda *= DEG_TO_RAD;
-            cs.Phi *= DEG_TO_RAD;
+            cs.Lambda = cs.Lambda / 3600 * DEG_TO_RAD;
+            cs.Phi = cs.Phi / 3600 * DEG_TO_RAD;
             CellSize = cs;
         }
 

--- a/Source/DotSpatial.Projections/GsbNadTable.cs
+++ b/Source/DotSpatial.Projections/GsbNadTable.cs
@@ -156,6 +156,7 @@ namespace DotSpatial.Projections
                     Cvs = cvs;
                 }
             }
+            Filled = true;
         }
 
         /// <summary>

--- a/Source/DotSpatial.Projections/Transforms/Transform.cs
+++ b/Source/DotSpatial.Projections/Transforms/Transform.cs
@@ -33,7 +33,7 @@ namespace DotSpatial.Projections.Transforms
     /// TransverseMercator is a class allowing the transverse mercator transform as transcribed
     /// from the 4.6 version of the Proj4 library (pj_tmerc.c)
     /// </summary>
-    public class Transform : ITransform
+    public class Transform : ProjDescriptor, ITransform
     {
         #region Private Variables
 


### PR DESCRIPTION
Due to the nature of the PLI DevTool sandbox, `GetEntryAssembly()` returns null. This pull request changes it to use `GetCallingAssembly()` in this case.