### PR TITLE
Fix Sandbox GetEntryAssembly Issue

### DIFF
--- a/Source/DotSpatial.Controls/AppManager.cs
+++ b/Source/DotSpatial.Controls/AppManager.cs
@@ -128,7 +128,7 @@ namespace DotSpatial.Controls
                 else
                 {
                     // by placing data in the AppData location, ClickOnce appications won't be subject to limits on size.
-                    Assembly asm = Assembly.GetEntryAssembly();
+                    Assembly asm = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
                     absolutePathToExtensions = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), asm.ManifestModule.Name, ExtensionsDirectory);
                 }
 
@@ -602,7 +602,7 @@ namespace DotSpatial.Controls
             var catalog = new AggregateCatalog();
 
             // Add main exe
-            Assembly mainExe = Assembly.GetEntryAssembly();
+            Assembly mainExe = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
             if (mainExe != null)
             {
                 // if there is a managed entry assembly running, add it.

--- a/Source/DotSpatial.Extensions/SplashScreens/SplashScreenHelper.cs
+++ b/Source/DotSpatial.Extensions/SplashScreens/SplashScreenHelper.cs
@@ -22,7 +22,7 @@ namespace DotSpatial.Extensions.SplashScreens
         public static ISplashScreenManager GetSplashScreenManager()
         {
             // This is a specific directory where a splash screen may be located.
-            Assembly asm = Assembly.GetEntryAssembly();
+            Assembly asm = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
             var directories = new List<string>
             {
                 AppDomain.CurrentDomain.BaseDirectory + "Application Extensions",


### PR DESCRIPTION
Due to the nature of the PLI DevTool sandbox, `GetEntryAssembly()` returns null. This pull request changes it to use` GetCallingAssembly()` in this case.